### PR TITLE
Adding OCI image-spec annotations to container definitions

### DIFF
--- a/datasciencelab/README.md
+++ b/datasciencelab/README.md
@@ -2,7 +2,6 @@
 This directory contains Dockerfiles for the JupyterLab containers offered by Omnia's JupyterHub installation. Container images contain the following:
 * Python3 kernel
 * R kernel
-* Julia kernel
 * TensorFlow 2.0.1
 * PyTorch 1.4.0
 * TensorBoard

--- a/datasciencelab/base/Dockerfile
+++ b/datasciencelab/base/Dockerfile
@@ -1,5 +1,14 @@
 FROM jupyter/base-notebook:lab-1.0.1
 
+LABEL org.opencontainers.image.title="Dell Data Science Lab - Base Container" \
+      org.opencontainers.image.description="A JupyterLab container with Python3 and R kernels, plus jupyterlab-git extension" \
+      org.opencontainers.image.author="Lucas A. Wilson" \
+      org.opencontainers.image.vendor="Dell Technologies" \
+      org.opencontainers.image.version="1.0" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/dellhpc/dockerfiles/datasciencelab/base/Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/dellhpc/dockerfiles/datasciencelab/README.md"
+
 ARG  JUPYTERHUB_VERSION=0.9.6
 
 USER root

--- a/datasciencelab/cpu/Dockerfile
+++ b/datasciencelab/cpu/Dockerfile
@@ -1,5 +1,14 @@
 FROM dellhpc/datasciencelab-base:1.0 
 
+LABEL org.opencontainers.image.title="Dell Data Science Lab - CPU Container" \
+      org.opencontainers.image.description="A JupyterLab container with CPU-optimized TensorFlow and PyTorch, plus TensorBoard" \
+      org.opencontainers.image.author="Lucas A. Wilson" \
+      org.opencontainers.image.vendor="Dell Technologies" \
+      org.opencontainers.image.version="1.0" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/dellhpc/dockerfiles/datasciencelab/cpu/Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/dellhpc/dockerfiles/datasciencelab/README.md"
+
 RUN  conda install --quiet --yes tensorflow pytorch-cpu && \ 
      conda clean --all -f -y && \
      pip install -U jupyter-tensorboard && \

--- a/datasciencelab/gpu/Dockerfile
+++ b/datasciencelab/gpu/Dockerfile
@@ -1,5 +1,14 @@
 FROM dellhpc/datasciencelab-base:1.0 
 
+LABEL org.opencontainers.image.title="Dell Data Science Lab - GPU Container" \
+      org.opencontainers.image.description="A JupyterLab container with Nvidia GPU-optimized TensorFlow and PyTorch, plus TensorBoard" \
+      org.opencontainers.image.author="Lucas A. Wilson" \
+      org.opencontainers.image.vendor="Dell Technologies" \
+      org.opencontainers.image.version="1.0" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/dellhpc/dockerfiles/datasciencelab/gpu/Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/dellhpc/dockerfiles/datasciencelab/README.md"
+
 RUN  conda install --quiet --yes tensorflow-gpu pytorch && \ 
      conda clean --all -f -y && \
      pip install -U jupyter-tensorboard && \


### PR DESCRIPTION
Following the OCI image specification at: https://github.com/opencontainers/image-spec/blob/master/annotations.md